### PR TITLE
Improve image build time

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -63,7 +63,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Create and push manifest list
         run: |
-          docker manifest create ${{ env.TAG }} \
-            ${{ env.TAG }}-amd64 \
-            ${{ env.TAG }}-arm64
-          docker manifest push ${{ env.TAG }}
+          docker buildx imagetools create -t ${{ env.TAG }} \
+            ${{ env.TAG }}-arm64 \
+            ${{ env.TAG }}-amd64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,12 @@
 on:
   push
 
+env:
+  TAG: sharinpix/docker-heroku:${{ (github.ref == 'refs/heads/main') && 'latest' || format('pr-gh-{0}', github.run_number) }}
+
 jobs:
-  docker:
-    name: Create Heroku Docker Image
+  build-amd64:
+    name: Build and Push AMD64 Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,10 +20,50 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+      - name: Build and push AMD64
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platform: linux/amd64
           push: true
-          tags: sharinpix/docker-heroku:${{ (github.ref == 'refs/heads/main') && 'latest' || format('pr-gh-{0}', github.run_number) }}
+          tags: ${{ env.TAG }}-amd64
+
+  build-arm64:
+    name: Build and Push ARM64 Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push ARM64
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platform: linux/arm64
+          push: true
+          tags: ${{ env.TAG }}-arm64
+
+  manifest:
+    name: Create and Push Docker Manifest
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create and push manifest list
+        run: |
+          docker manifest create ${{ env.TAG }} \
+            ${{ env.TAG }}-amd64 \
+            ${{ env.TAG }}-arm64
+          docker manifest push ${{ env.TAG }}


### PR DESCRIPTION
https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

We used to build each platform (arm and amd) on the same runner which took a long time to complete (>1 hour)

To solve this issue we can build each platform across multiple runners. (now ~6 mins)