### PR TITLE
Update ubuntu version to 24.04 - SP-9713

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,11 @@ RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && truncate -s 0 /var/log/*log
 
-RUN adduser --gecos '' user && passwd -d user
+# Remove the default ubuntu user (UID 1000 in Ubuntu 24.04) and create our user with UID 1000
+# This prevents permission conflicts when mounting volumes
+RUN (id ubuntu &>/dev/null && userdel -r ubuntu) || true && \
+    adduser --uid 1000 --gecos '' --disabled-password user && \
+    passwd -d user
 
 RUN mkdir /app && mkdir /nginx && mkdir /bundle && mkdir /home/user/.sfdx && chown user:user /app /bundle /home/user/.sfdx /nginx /var/log/nginx
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,12 @@
+## Main use case (User story)
+
+
+## How? (Comments on implementation)
+
+
+## PR checklist:
+
+- [ ]  I reviewed my code
+- [ ]  A senior reviewed it
+- [ ]  Commits are meaningful
+- [ ]  The business case and why we want this change is well described here SP-


### PR DESCRIPTION
## Main use case (User story)
+ Ubuntu 24.04 has stricter directory permissions. It comes with a default user `ubuntu` which causes permission errors since it becomes owner of `/app` and our user `user` cannot create folders or files.

## How? (Comments on implementation) 
+ Remove the default ubuntu user (UID 1000 in Ubuntu 24.04) and create our 'user' with UID 1000. This prevents permission conflicts when mounting volumes

+ Add `pull_request_template.md` for next pull requests.

## PR checklist:

- [x]  I reviewed my code
- [ ]  A senior reviewed it
- [x]  Commits are meaningful
- [x]  The business case and why we want this change is well described here SP-9713